### PR TITLE
Fixed logic that was preventing property from being read

### DIFF
--- a/src/webparts/peoplesearch/PeopleSearchWebPart.ts
+++ b/src/webparts/peoplesearch/PeopleSearchWebPart.ts
@@ -282,7 +282,7 @@ export default class PeopleSearchWebPart extends BaseClientSideWebPart<IPeopleSe
         deferredValidationTime: 300,
         onGetErrorMessage: (value: string) => {
           return this._validateNumber(value);
-        } 
+        }
       }),
     ];
 
@@ -362,7 +362,7 @@ export default class PeopleSearchWebPart extends BaseClientSideWebPart<IPeopleSe
 
   /**
   * Checks if all webpart properties have been configured
-  */ 
+  */
   private _isWebPartConfigured(): boolean {
     return true;
   }
@@ -372,7 +372,7 @@ export default class PeopleSearchWebPart extends BaseClientSideWebPart<IPeopleSe
   */
   private _initializeRequiredProperties() {
     this.properties.selectedLayout = !isEmpty(this.properties.selectedLayout) ? this.properties.selectedLayout : ResultsLayoutOption.People;
-    this.properties.searchParameterOption = !isEmpty(this.properties.searchParameterOption) ? this.properties.searchParameterOption : SearchParameterOption.None;
+    this.properties.searchParameterOption = (this.properties.searchParameterOption) ? this.properties.searchParameterOption : SearchParameterOption.None;
     this.properties.templateParameters = this.properties.templateParameters ? this.properties.templateParameters : {};
   }
 


### PR DESCRIPTION
While trying to switch the search property to search box, I found the web part kept resetting the search property to None on load.

It seems isEmpty doesn't like numbers so the property was always set to the default.