### PR TITLE
WIP user query only fires on search

### DIFF
--- a/src/webparts/peoplesearch/components/PeopleSearchBox/IPeopleSearchBoxState.ts
+++ b/src/webparts/peoplesearch/components/PeopleSearchBox/IPeopleSearchBoxState.ts
@@ -1,4 +1,5 @@
 export interface IPeopleSearchBoxState {
     searchInputValue: string;
     showClearButton: boolean;
+    isLoading: boolean;
 }

--- a/src/webparts/peoplesearch/components/PeopleSearchBox/PeopleSearchBox.tsx
+++ b/src/webparts/peoplesearch/components/PeopleSearchBox/PeopleSearchBox.tsx
@@ -33,7 +33,7 @@ export class PeopleSearchBox extends React.Component<IPeopleSearchBoxProps,IPeop
                   className={styles.searchTextField}
                   value={this.state.searchInputValue}
                   autoComplete="off"
-                  onChange={(value) => this.setState({ searchInputValue: value })}
+                  onChange={(value) => this._onChange(value)}
                   onSearch={() => this._onSearch(this.state.searchInputValue)}
                   onClear={() => this._onSearch('', true)}
               />
@@ -62,17 +62,28 @@ export class PeopleSearchBox extends React.Component<IPeopleSearchBoxProps,IPeop
           let query = queryText;
 
           this.setState({
-              searchInputValue: queryText,
               showClearButton: !isReset
           });
 
           let element = document.activeElement as HTMLElement;
           if (element) {
-              element.blur();
+              // element.blur();
           }
 
           // Notify the dynamic data controller
           this.props.onSearch(query);
+      }
+  }
+
+  public _onChange(value) {
+      // TODO SET TIMEOUT, ONLY RUN ON 2 or 3 Character inputs
+      console.log(`Value: ${value}`);
+      this.setState({
+          searchInputValue: value
+      })
+      console.log(this.state.searchInputValue.length);
+      if (this.state.searchInputValue.length > 1) {
+        this._onSearch(this.state.searchInputValue);  
       }
   }
 

--- a/src/webparts/peoplesearch/components/PeopleSearchBox/PeopleSearchBox.tsx
+++ b/src/webparts/peoplesearch/components/PeopleSearchBox/PeopleSearchBox.tsx
@@ -9,6 +9,7 @@ import { IPeopleSearchBoxState } from "./IPeopleSearchBoxState";
 import {
   IconButton,
   SearchBox,
+  Spinner,
   ITheme
 } from "office-ui-fabric-react";
 
@@ -21,6 +22,7 @@ export class PeopleSearchBox extends React.Component<IPeopleSearchBoxProps,IPeop
     this.state = {
         searchInputValue: props.searchInputValue,
         showClearButton: false,
+        isLoading: false
     };
   }
 
@@ -62,7 +64,8 @@ export class PeopleSearchBox extends React.Component<IPeopleSearchBoxProps,IPeop
           let query = queryText;
 
           this.setState({
-              showClearButton: !isReset
+              showClearButton: !isReset,
+              isLoading: false
           });
 
           // Notify the dynamic data controller
@@ -72,8 +75,11 @@ export class PeopleSearchBox extends React.Component<IPeopleSearchBoxProps,IPeop
 
   public _onChange(value) {
       this.setState({
-          searchInputValue: value
+          searchInputValue: value,
+          isLoading: true
       });
+      // The following will run after the user types 3 characters
+      // The state is behind by 1 at the check, this is why it is set to 2
       if (this.state.searchInputValue.length >= 2) {
         this._onSearch(this.state.searchInputValue);  
       }
@@ -83,6 +89,7 @@ export class PeopleSearchBox extends React.Component<IPeopleSearchBoxProps,IPeop
       return (
           <div className={styles.searchBox}>
               {this.renderBasicSearchBox()}
+              {this.state.isLoading && <span>{strings.ContinueTyping}<Spinner /></span>}
           </div>
       );
   }

--- a/src/webparts/peoplesearch/components/PeopleSearchBox/PeopleSearchBox.tsx
+++ b/src/webparts/peoplesearch/components/PeopleSearchBox/PeopleSearchBox.tsx
@@ -65,11 +65,6 @@ export class PeopleSearchBox extends React.Component<IPeopleSearchBoxProps,IPeop
               showClearButton: !isReset
           });
 
-          let element = document.activeElement as HTMLElement;
-          if (element) {
-              // element.blur();
-          }
-
           // Notify the dynamic data controller
           this.props.onSearch(query);
       }
@@ -79,7 +74,7 @@ export class PeopleSearchBox extends React.Component<IPeopleSearchBoxProps,IPeop
       this.setState({
           searchInputValue: value
       });
-      if (this.state.searchInputValue.length > 1) {
+      if (this.state.searchInputValue.length >= 2) {
         this._onSearch(this.state.searchInputValue);  
       }
   }

--- a/src/webparts/peoplesearch/components/PeopleSearchBox/PeopleSearchBox.tsx
+++ b/src/webparts/peoplesearch/components/PeopleSearchBox/PeopleSearchBox.tsx
@@ -76,12 +76,9 @@ export class PeopleSearchBox extends React.Component<IPeopleSearchBoxProps,IPeop
   }
 
   public _onChange(value) {
-      // TODO SET TIMEOUT, ONLY RUN ON 2 or 3 Character inputs
-      console.log(`Value: ${value}`);
       this.setState({
           searchInputValue: value
-      })
-      console.log(this.state.searchInputValue.length);
+      });
       if (this.state.searchInputValue.length > 1) {
         this._onSearch(this.state.searchInputValue);  
       }

--- a/src/webparts/peoplesearch/components/PeopleSearchContainer/PeopleSearchContainer.tsx
+++ b/src/webparts/peoplesearch/components/PeopleSearchContainer/PeopleSearchContainer.tsx
@@ -42,11 +42,6 @@ export class PeopleSearchContainer extends React.Component<IPeopleSearchContaine
     };
   }
 
-  public async componentDidMount() {
-    console.log('MOUNTED');
-    // await this._fetchPeopleSearchResults(1, true);
-  }
-
   /**
    *
    *

--- a/src/webparts/peoplesearch/components/PeopleSearchContainer/PeopleSearchContainer.tsx
+++ b/src/webparts/peoplesearch/components/PeopleSearchContainer/PeopleSearchContainer.tsx
@@ -43,7 +43,8 @@ export class PeopleSearchContainer extends React.Component<IPeopleSearchContaine
   }
 
   public async componentDidMount() {
-    await this._fetchPeopleSearchResults(1, true);
+    console.log('MOUNTED');
+    // await this._fetchPeopleSearchResults(1, true);
   }
 
   /**
@@ -184,7 +185,7 @@ export class PeopleSearchContainer extends React.Component<IPeopleSearchContaine
       <div style={{backgroundColor: semanticColors.bodyBackground}}>
         <div className={styles.peopleSearchWebPart}>
           {renderWebPartTitle}
-          {renderShimmerElements ? renderShimmerElements : renderWebPartContent}
+          {renderWebPartContent}
         </div>
       </div>
     );

--- a/src/webparts/peoplesearch/loc/en-us.js
+++ b/src/webparts/peoplesearch/loc/en-us.js
@@ -45,5 +45,6 @@ define([], function() {
       "PersonaSizeLarge": "Large",
       "PersonaSizeExtraLarge": "Extra large",
     },
+    "ContinueTyping": "Continue Typing",
   }
 });

--- a/src/webparts/peoplesearch/loc/mystrings.d.ts
+++ b/src/webparts/peoplesearch/loc/mystrings.d.ts
@@ -44,6 +44,7 @@ declare interface IPeopleSearchWebPartStrings {
     PersonaSizeLarge: string;
     PersonaSizeExtraLarge: string;
   }
+  ContinueTyping: string;
 }
 
 declare module 'PeopleSearchWebPartStrings' {


### PR DESCRIPTION
Modifying the web part to only query for users after a few characters have been entered in the search box.

The reason is to prevent a potential large query of users on the component mount.

You must now have the "Search Box" option checked to use the webpart